### PR TITLE
Improve ignored blocks handling

### DIFF
--- a/src/main/java/me/vilsol/blockly2java/Blockly2Java.java
+++ b/src/main/java/me/vilsol/blockly2java/Blockly2Java.java
@@ -1,211 +1,222 @@
 package me.vilsol.blockly2java;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import me.vilsol.blockly2java.annotations.BBlock;
 import me.vilsol.blockly2java.annotations.BField;
 import me.vilsol.blockly2java.annotations.BStatement;
 import me.vilsol.blockly2java.annotations.BValue;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class Blockly2Java {
 
-    private static final Blockly2Java instance = new Blockly2Java();
+	private static final Blockly2Java instance = new Blockly2Java();
 
-    private final Map<String, BlocklyBlock> blocks = new HashMap<>();
-    private final Pattern nodePattern = Pattern.compile("(<.*?>)([^<>]*)");
-    private final Pattern attributePattern = Pattern.compile("([a-zA-Z0-9]+)=\"(.+?)\"");
+	private final Map<String, BlocklyBlock> blocks = new HashMap<>();
+	private final Pattern nodePattern = Pattern.compile("(<.*?>)([^<>]*)");
+	private final Pattern attributePattern = Pattern.compile("([a-zA-Z0-9]+)=\"(.+?)\"");
 
-    protected static Blockly2Java getInstance() {
-        return instance;
-    }
+	protected static Blockly2Java getInstance() {
+		return instance;
+	}
 
-    /**
-     * Register a class to be used as an object for converting blockly to java object
-     *
-     * @param block The class of the object
-     */
-    public static void registerClass(Class<?> block){
-        BBlock b = block.getAnnotation(BBlock.class);
-        if(b == null){
-            throw new RuntimeException("Tried to register block (" + block.getName() + ") without @BBlock annotation");
-        }
+	/**
+	 * Register a class to be used as an object for converting blockly to java object
+	 *
+	 * @param block The class of the object
+	 */
+	public static void registerClass(Class<?> block){
+		BBlock b = block.getAnnotation(BBlock.class);
+		if(b == null){
+			throw new RuntimeException("Tried to register block (" + block.getName() + ") without @BBlock annotation");
+		}
 
-        Map<String, Field> blockFields = new HashMap<>();
-        Map<String, Field> blockValues = new HashMap<>();
-        Map<String, Field> blockStatements = new HashMap<>();
+		Map<String, Field> blockFields = new HashMap<>();
+		Map<String, Field> blockValues = new HashMap<>();
+		Map<String, Field> blockStatements = new HashMap<>();
 
-        Field[] fields = block.getDeclaredFields();
-        for(Field field : fields){
-            Annotation f;
-            if((f = field.getAnnotation(BField.class)) != null){
-                blockFields.put(((BField) f).value(), field);
-            }else if((f = field.getAnnotation(BValue.class)) != null){
-                if(field.getDeclaringClass().getAnnotation(BBlock.class) == null){
-                    throw new RuntimeException("Class:" + block.getName() + " Should be a @BBlock class!");
-                }
-                blockValues.put(((BValue) f).value(), field);
-            }else if((f = field.getAnnotation(BStatement.class)) != null){
-                if(!field.getType().isAssignableFrom(List.class)){
-                    throw new RuntimeException("Class:" + block.getName() + " Field:" + field.getName() + " Should be a list!");
-                }
-                blockStatements.put(((BStatement) f).value(), field);
-            }
+		Field[] fields = block.getDeclaredFields();
+		for(Field field : fields){
+			Annotation f;
+			if((f = field.getAnnotation(BField.class)) != null){
+				blockFields.put(((BField) f).value(), field);
+			}else if((f = field.getAnnotation(BValue.class)) != null){
+				if(field.getDeclaringClass().getAnnotation(BBlock.class) == null){
+					throw new RuntimeException("Class:" + block.getName() + " Should be a @BBlock class!");
+				}
+				blockValues.put(((BValue) f).value(), field);
+			}else if((f = field.getAnnotation(BStatement.class)) != null){
+				if(!field.getType().isAssignableFrom(List.class)){
+					throw new RuntimeException("Class:" + block.getName() + " Field:" + field.getName() + " Should be a list!");
+				}
+				blockStatements.put(((BStatement) f).value(), field);
+			}
 
-            if(f != null){
-                field.setAccessible(true);
-            }
-        }
+			if(f != null){
+				field.setAccessible(true);
+			}
+		}
 
-        getInstance().blocks.put(b.value(), new BlocklyBlock(block, b.value(), blockFields, blockValues, blockStatements));
-    }
+		getInstance().blocks.put(b.value(), new BlocklyBlock(block, b.value(), blockFields, blockValues, blockStatements));
+	}
 
-    /**
-     * Parse blockly XML structure and convert into an object
-     *
-     * @param blockly Blockly XML structure
-     * @return List of parent-most blocks
-     */
-    public static ArrayList<Object> parseBlockly(String blockly){
-        Matcher m = getInstance().nodePattern.matcher(blockly);
-        Stack<Node> nodes = new Stack<>();
-        ArrayList<Object> blocks = new ArrayList<>();
+	/**
+	 * Parse blockly XML structure and convert into an object
+	 *
+	 * @param blockly Blockly XML structure
+	 * @return List of parent-most blocks
+	 */
+	public static ArrayList<Object> parseBlockly(String blockly){
+		Matcher m = getInstance().nodePattern.matcher(blockly);
+		Stack<Node> nodes = new Stack<>();
+		ArrayList<Object> blocks = new ArrayList<>();
+		List<String> ignoredBlockIds = new ArrayList<>();
+		boolean ignoreNext = false;
+		Node lastNode = null;
+		while(m.find()){
+			if(!m.group(1).startsWith("</")) {
+				Node node = getNode(m.group(1), m.group(2));
+				if(node.getName().equals("mutation")){
+					continue;
+				}
 
-        Node lastNode = null;
-        int ignoreBlocks = 0;
-        while(m.find()){
-            if(!m.group(1).startsWith("</")) {
-                Node node = getNode(m.group(1), m.group(2));
-                if(node.getName().equals("mutation")){
-                    continue;
-                }
+				if (ignoreNext) {
+					ignoredBlockIds.add(node.getAttributes().get("id"));
+					ignoreNext = false;
+				}
 
-                if(node.getName().equals("next")){
-                    nodes.pop();
-                    lastNode = nodes.peek();
-                    ignoreBlocks++;
-                    continue;
-                }
+				if(node.getName().equals("next")){
+					nodes.pop();
+					lastNode = nodes.peek();
+					ignoreNext = true;
+					continue;
+				}
 
-                if (lastNode != null) {
-                    lastNode.addSubnode(node);
-                }
+				if (lastNode != null) {
+					lastNode.addSubnode(node);
+				}
 
-                nodes.add(node);
-                lastNode = node;
-            }else{
-                if(m.group(1).equals("</mutation>")){
-                    continue;
-                }
+				nodes.add(node);
+				lastNode = node;
+			}else{
+				if(m.group(1).equals("</mutation>")){
+					continue;
+				}
 
-                if(nodes.size() > 0) {
-                    if (nodes.peek().getName().equals("block") && ignoreBlocks > 0) {
-                        ignoreBlocks--;
-                    } else if (!m.group(1).contains("next")) {
-                        nodes.pop();
-                        if (nodes.size() > 0) {
-                            lastNode = nodes.peek();
-                        }
-                    }
-                }
+				if(nodes.size() > 0) {
+					Node p = nodes.peek();
+					String id;
+					if (p.getName().equals("block") && ignoredBlockIds.contains(id = p.getAttributes().get("id"))) {
+						ignoredBlockIds.remove(id);
+					} else if (!m.group(1).contains("next")) {
+						nodes.pop();
+						if (nodes.size() > 0) {
+							lastNode = nodes.peek();
+						}
+					}
+				}
 
-                if(nodes.size() == 0){
-                    if(m.group(1).equals("</block>")) {
-                        blocks.add(parseBlock(lastNode));
-                    }
-                }
-            }
-        }
+				if(nodes.size() == 0){
+					if(m.group(1).equals("</block>")) {
+						blocks.add(parseBlock(lastNode));
+					}
+				}
+			}
+		}
 
-        return blocks;
-    }
+		return blocks;
+	}
 
-    private static Object parseBlock(Node node){
-        BlocklyBlock baseBlock = getInstance().blocks.get(node.getAttributes().get("type"));
-        if(baseBlock == null){
-            throw new RuntimeException("No block with type '" + node.getAttributes().get("type") + "' registered!");
-        }
+	private static Object parseBlock(Node node){
+		BlocklyBlock baseBlock = getInstance().blocks.get(node.getAttributes().get("type"));
+		if(baseBlock == null){
+			throw new RuntimeException("No block with type '" + node.getAttributes().get("type") + "' registered!");
+		}
 
-        Object base = baseBlock.newInstance();
-        fillBlock(baseBlock, base, node);
-        return base;
-    }
+		Object base = baseBlock.newInstance();
+		fillBlock(baseBlock, base, node);
+		return base;
+	}
 
-    private static void fillBlock(BlocklyBlock block, Object base, Node node){
-        if(node.getSubnodes() == null || node.getSubnodes().size() == 0){
-            return;
-        }
+	private static void fillBlock(BlocklyBlock block, Object base, Node node){
+		if(node.getSubnodes() == null || node.getSubnodes().size() == 0){
+			return;
+		}
 
-        for(Node s : node.getSubnodes()){
-            String fieldName = s.getAttributes().get("name");
+		for(Node s : node.getSubnodes()){
+			String fieldName = s.getAttributes().get("name");
 
-            switch(s.getName()){
-                case "field":
-                    Field field = block.getFields().get(fieldName);
+			switch(s.getName()){
+			case "field":
+				Field field = block.getFields().get(fieldName);
 
-                    if(field == null){
-                        throw new RuntimeException("Field '" + fieldName + "' not found in " + base.getClass().getName());
-                    }
+				if(field == null){
+					throw new RuntimeException("Field '" + fieldName + "' not found in " + base.getClass().getName());
+				}
 
-                    if(field.getType().equals(int.class) || field.getType().equals(Integer.class)){
-                        setValue(base, fieldName, field, Integer.parseInt(s.getValue()));
-                    }else if(field.getType().equals(double.class) || field.getType().equals(Double.class)) {
-                        setValue(base, fieldName, field, Double.parseDouble(s.getValue()));
-                    }else if(field.getType().equals(float.class) || field.getType().equals(Float.class)) {
-                        setValue(base, fieldName, field, Float.parseFloat(s.getValue()));
-                    }else if(field.getType().equals(long.class) || field.getType().equals(Long.class)) {
-                        setValue(base, fieldName, field, Long.parseLong(s.getValue()));
-                    }else if(field.getType().equals(boolean.class) || field.getType().equals(Boolean.class)) {
-                        setValue(base, fieldName, field, Boolean.parseBoolean(s.getValue()));
-                    }else if(field.getType().isEnum()) {
-                        setValue(base, fieldName, field, field.getType().getEnumConstants()[Integer.parseInt(s.getValue())]);
-                    }else{
-                        setValue(base, fieldName, field, s.getValue());
-                    }
-                    break;
-                case "value":
-                    setValue(base, fieldName, block.getValues().get(fieldName), parseBlock(s.getSubnodes().iterator().next()));
-                    break;
-                case "statement":
-                    List<Object> objects = new ArrayList<>();
-                    if(s.getSubnodes() != null && s.getSubnodes().size() > 0){
-                        for(Node n : s.getSubnodes()){
-                            objects.add(parseBlock(n));
-                        }
-                    }
-                    setValue(base, fieldName, block.getStatements().get(fieldName), objects);
-                    break;
-            }
-        }
+				if(field.getType().equals(int.class) || field.getType().equals(Integer.class)){
+					setValue(base, fieldName, field, Integer.parseInt(s.getValue()));
+				}else if(field.getType().equals(double.class) || field.getType().equals(Double.class)) {
+					setValue(base, fieldName, field, Double.parseDouble(s.getValue()));
+				}else if(field.getType().equals(float.class) || field.getType().equals(Float.class)) {
+					setValue(base, fieldName, field, Float.parseFloat(s.getValue()));
+				}else if(field.getType().equals(long.class) || field.getType().equals(Long.class)) {
+					setValue(base, fieldName, field, Long.parseLong(s.getValue()));
+				}else if(field.getType().equals(boolean.class) || field.getType().equals(Boolean.class)) {
+					setValue(base, fieldName, field, Boolean.parseBoolean(s.getValue()));
+				}else if(field.getType().isEnum()) {
+					setValue(base, fieldName, field, field.getType().getEnumConstants()[Integer.parseInt(s.getValue())]);
+				}else{
+					setValue(base, fieldName, field, s.getValue());
+				}
+				break;
+			case "value":
+				setValue(base, fieldName, block.getValues().get(fieldName), parseBlock(s.getSubnodes().iterator().next()));
+				break;
+			case "statement":
+				List<Object> objects = new ArrayList<>();
+				if(s.getSubnodes() != null && s.getSubnodes().size() > 0){
+					for(Node n : s.getSubnodes()){
+						objects.add(parseBlock(n));
+					}
+				}
+				setValue(base, fieldName, block.getStatements().get(fieldName), objects);
+				break;
+			}
+		}
 
-        if(base instanceof BlocklyAfterParsed){
-            ((BlocklyAfterParsed) base).onFinish();
-        }
-    }
+		if(base instanceof BlocklyAfterParsed){
+			((BlocklyAfterParsed) base).onFinish();
+		}
+	}
 
-    private static void setValue(Object object, String fieldName, Field field, Object value){
-        try {
-            field.set(object, value);
-        } catch (Exception e) {
-            if(field == null){
-                throw new RuntimeException("Object '" + object.getClass().getName() + "' does not contain field '" + fieldName + "'");
-            }else{
-                throw new RuntimeException("Exception '" + e.getMessage() + "' whilst trying to set '" + fieldName + "' in object " + object.getClass().getName());
-            }
-        }
-    }
+	private static void setValue(Object object, String fieldName, Field field, Object value){
+		try {
+			field.set(object, value);
+		} catch (Exception e) {
+			if(field == null){
+				throw new RuntimeException("Object '" + object.getClass().getName() + "' does not contain field '" + fieldName + "'");
+			}else{
+				throw new RuntimeException("Exception '" + e.getMessage() + "' whilst trying to set '" + fieldName + "' in object " + object.getClass().getName());
+			}
+		}
+	}
 
-    private static Node getNode(String node, String value){
-        String name = node.split("\\s")[0].split(">")[0].substring(1);
-        Matcher m = getInstance().attributePattern.matcher(node);
-        Map<String, String> attributes = new HashMap<>();
-        while(m.find()){
-            attributes.put(m.group(1), m.group(2));
-        }
-        return new Node(name, attributes, value);
-    }
+	private static Node getNode(String node, String value){
+		String name = node.split("\\s")[0].split(">")[0].substring(1);
+		Matcher m = getInstance().attributePattern.matcher(node);
+		Map<String, String> attributes = new HashMap<>();
+		while(m.find()){
+			attributes.put(m.group(1), m.group(2));
+		}
+		return new Node(name, attributes, value);
+	}
 
 }

--- a/src/test/java/me/vilsol/blockly2java/Blockly2JavaTest.java
+++ b/src/test/java/me/vilsol/blockly2java/Blockly2JavaTest.java
@@ -1,57 +1,85 @@
 package me.vilsol.blockly2java;
 
-import me.vilsol.blockly2java.objects.*;
+import java.util.ArrayList;
+
+import me.vilsol.blockly2java.objects.CaptionEvent;
+import me.vilsol.blockly2java.objects.ComplexDelayEvent;
+import me.vilsol.blockly2java.objects.ComplexTime;
+import me.vilsol.blockly2java.objects.Cutscene;
+import me.vilsol.blockly2java.objects.Data;
+import me.vilsol.blockly2java.objects.DelayEvent;
+import me.vilsol.blockly2java.objects.Dialogue;
+import me.vilsol.blockly2java.objects.DialogueClose;
+import me.vilsol.blockly2java.objects.DialogueOpenDialogue;
+import me.vilsol.blockly2java.objects.DialogueOption;
+import me.vilsol.blockly2java.objects.DialogueSayMessage;
+import me.vilsol.blockly2java.objects.SmoothMoveEvent;
+import me.vilsol.blockly2java.objects.TeleportEvent;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
-
 public class Blockly2JavaTest {
 
-    private static String cutsceneInput = "<block type=\"cutscene_base\" id=\"1\" deletable=\"false\" movable=\"false\" x=\"0\" y=\"0\"><value name=\"DATA\"><block type=\"cutscene_data\" id=\"2\" inline=\"false\"><field name=\"NAME\">TestScene</field><field name=\"FADING\">TRUE</field></block></value><statement name=\"EVENTS\"><block type=\"event_delay\" id=\"6\"><field name=\"TIME\">20</field><next><block type=\"event_teleport\" id=\"11\"><field name=\"X\">1.1</field><field name=\"Y\">2.2</field><field name=\"Z\">3.3</field><field name=\"PITCH\">4.4</field><field name=\"YAW\">5.5</field><next><block type=\"event_smooth_move\" id=\"16\"><field name=\"X\">6.6</field><field name=\"Y\">7.7</field><field name=\"Z\">8.8</field><field name=\"PITCH\">9.9</field><field name=\"YAW\">10</field><next><block type=\"event_caption\" id=\"21\"><field name=\"TITLE\">Test Title</field><field name=\"SUBTITLE\">Test Subtitle</field></block></next></block></next></block></next></block></statement></block>";
-    private static String dialogueInput = "<block type=\"dialogue_tree_base\" id=\"1\" x=\"154\" y=\"124\"><field name=\"TREE_NAME\">base</field><statement name=\"OPTIONS\"><block type=\"dialogue_tree_option\" id=\"2\"><field name=\"MESSAGE\">Hello</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"3\"><field name=\"MESSAGE\">Hello</field><next><block type=\"dialogue_tree_action_open\" id=\"4\"><field name=\"TREE\">base</field></block></next></block></statement><next><block type=\"dialogue_tree_option\" id=\"5\"><field name=\"MESSAGE\">Who am I?</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"6\"><field name=\"MESSAGE\">Yer' a wizard, Harry!</field><next><block type=\"dialogue_tree_action_open\" id=\"7\"><field name=\"TREE\">whoami</field></block></next></block></statement><next><block type=\"dialogue_tree_option\" id=\"8\"><field name=\"MESSAGE\">Bye</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_close\" id=\"9\"></block></statement></block></next></block></next></block></statement></block><block type=\"dialogue_tree_base\" id=\"21\" x=\"873\" y=\"174\"><field name=\"TREE_NAME\">testy</field><statement name=\"OPTIONS\"><block type=\"dialogue_tree_option\" id=\"27\"><field name=\"MESSAGE\">Hello</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"39\"><field name=\"MESSAGE\">What</field></block></statement></block></statement></block><block type=\"dialogue_tree_base\" id=\"10\" x=\"520\" y=\"223\"><field name=\"TREE_NAME\">whoami</field><statement name=\"OPTIONS\"><block type=\"dialogue_tree_option\" id=\"11\"><field name=\"MESSAGE\">A wizard?!?</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"12\"><field name=\"MESSAGE\">Yes! A wizard!</field><next><block type=\"dialogue_tree_action_open\" id=\"13\"><field name=\"TREE\">base</field></block></next></block></statement><next><block type=\"dialogue_tree_option\" id=\"14\"><field name=\"MESSAGE\">Oh, ok...</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_open\" id=\"15\"><field name=\"TREE\">base</field></block></statement></block></next></block></statement></block>";
+	private static String cutsceneInput = "<block type=\"cutscene_base\" id=\"1\" deletable=\"false\" movable=\"false\" x=\"0\" y=\"0\"><value name=\"DATA\"><block type=\"cutscene_data\" id=\"2\" inline=\"false\"><field name=\"NAME\">TestScene</field><field name=\"FADING\">TRUE</field></block></value><statement name=\"EVENTS\"><block type=\"event_delay\" id=\"6\"><field name=\"TIME\">20</field><next><block type=\"event_teleport\" id=\"11\"><field name=\"X\">1.1</field><field name=\"Y\">2.2</field><field name=\"Z\">3.3</field><field name=\"PITCH\">4.4</field><field name=\"YAW\">5.5</field><next><block type=\"event_smooth_move\" id=\"16\"><field name=\"X\">6.6</field><field name=\"Y\">7.7</field><field name=\"Z\">8.8</field><field name=\"PITCH\">9.9</field><field name=\"YAW\">10</field><next><block type=\"event_caption\" id=\"21\"><field name=\"TITLE\">Test Title</field><field name=\"SUBTITLE\">Test Subtitle</field></block></next></block></next></block></next></block></statement></block>";
+	private static String dialogueInput = "<block type=\"dialogue_tree_base\" id=\"1\" x=\"154\" y=\"124\"><field name=\"TREE_NAME\">base</field><statement name=\"OPTIONS\"><block type=\"dialogue_tree_option\" id=\"2\"><field name=\"MESSAGE\">Hello</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"3\"><field name=\"MESSAGE\">Hello</field><next><block type=\"dialogue_tree_action_open\" id=\"4\"><field name=\"TREE\">base</field></block></next></block></statement><next><block type=\"dialogue_tree_option\" id=\"5\"><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"6\"><field name=\"MESSAGE\">Yer' a wizard, Harry!</field><next><block type=\"dialogue_tree_action_open\" id=\"7\"><field name=\"TREE\">whoami</field></block></next></block></statement><field name=\"MESSAGE\">Who am I?</field><next><block type=\"dialogue_tree_option\" id=\"8\"><field name=\"MESSAGE\">Bye</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_close\" id=\"9\"></block></statement></block></next></block></next></block></statement></block><block type=\"dialogue_tree_base\" id=\"21\" x=\"873\" y=\"174\"><field name=\"TREE_NAME\">testy</field><statement name=\"OPTIONS\"><block type=\"dialogue_tree_option\" id=\"27\"><field name=\"MESSAGE\">Hello</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"39\"><field name=\"MESSAGE\">What</field></block></statement></block></statement></block><block type=\"dialogue_tree_base\" id=\"10\" x=\"520\" y=\"223\"><field name=\"TREE_NAME\">whoami</field><statement name=\"OPTIONS\"><block type=\"dialogue_tree_option\" id=\"11\"><field name=\"MESSAGE\">A wizard?!?</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_say\" id=\"12\"><field name=\"MESSAGE\">Yes! A wizard!</field><next><block type=\"dialogue_tree_action_open\" id=\"13\"><field name=\"TREE\">base</field></block></next></block></statement><next><block type=\"dialogue_tree_option\" id=\"14\"><field name=\"MESSAGE\">Oh, ok...</field><statement name=\"ACTIONS\"><block type=\"dialogue_tree_action_open\" id=\"15\"><field name=\"TREE\">base</field></block></statement></block></next></block></statement></block>";
+	private static String complexCutsceneInput = "<block type=\"cutscene_base\" id=\"1\" deletable=\"false\" movable=\"false\" x=\"0\" y=\"0\"><value name=\"DATA\"><block type=\"cutscene_data\" id=\"2\"><field name=\"NAME\">TestScene</field><field name=\"FADING\">TRUE</field></block></value><statement name=\"EVENTS\"><block type=\"event_complex_delay\" id=\"10\"><value name=\"START\"><block type=\"complex_time\" id=\"2\"><field name=\"MINUTES\">1</field><field name=\"SECONDS\">50</field></block></value> <value name=\"END\"><block type=\"complex_time\" id=\"3\"><field name=\"MINUTES\">4</field><field name=\"SECONDS\">40</field></block></value><next><block type=\"event_complex_delay\" id=\"11\"><value name=\"START\"><block type=\"complex_time\" id=\"4\"><field name=\"MINUTES\">1</field><field name=\"SECONDS\">50</field></block></value><value name=\"END\"><block type=\"complex_time\" id=\"5\"><field name=\"MINUTES\">4</field><field name=\"SECONDS\">40</field></block></value></block></next></block></statement></block>";
 
-    @Test
-    public void testClass() throws Exception {
-        Blockly2Java.registerClass(Cutscene.class);
-        Blockly2Java.registerClass(Data.class);
-        Blockly2Java.registerClass(CaptionEvent.class);
-        Blockly2Java.registerClass(DelayEvent.class);
-        Blockly2Java.registerClass(SmoothMoveEvent.class);
-        Blockly2Java.registerClass(TeleportEvent.class);
+	@Test
+	public void testClass() throws Exception {
+		Blockly2Java.registerClass(Cutscene.class);
+		Blockly2Java.registerClass(Data.class);
+		Blockly2Java.registerClass(CaptionEvent.class);
+		Blockly2Java.registerClass(DelayEvent.class);
+		Blockly2Java.registerClass(SmoothMoveEvent.class);
+		Blockly2Java.registerClass(TeleportEvent.class);
 
-        Cutscene cutscene = (Cutscene) Blockly2Java.parseBlockly(cutsceneInput).get(0);
+		Cutscene cutscene = (Cutscene) Blockly2Java.parseBlockly(cutsceneInput).get(0);
 
-        Assert.assertEquals(true, cutscene.data.fading);
-        Assert.assertEquals("TestScene", cutscene.data.name);
+		Assert.assertEquals(true, cutscene.data.fading);
+		Assert.assertEquals("TestScene", cutscene.data.name);
 
-        Assert.assertEquals(20, ((DelayEvent) cutscene.events.get(0)).time);
+		Assert.assertEquals(20, ((DelayEvent) cutscene.events.get(0)).time);
 
-        Assert.assertEquals(1.1, ((TeleportEvent) cutscene.events.get(1)).x, 0);
-        Assert.assertEquals(2.2, ((TeleportEvent) cutscene.events.get(1)).y, 0);
-        Assert.assertEquals(3.3, ((TeleportEvent) cutscene.events.get(1)).z, 0);
-        Assert.assertEquals(4.4, ((TeleportEvent) cutscene.events.get(1)).pitch, 0.01);
-        Assert.assertEquals(5.5, ((TeleportEvent) cutscene.events.get(1)).yaw, 0.01);
+		Assert.assertEquals(1.1, ((TeleportEvent) cutscene.events.get(1)).x, 0);
+		Assert.assertEquals(2.2, ((TeleportEvent) cutscene.events.get(1)).y, 0);
+		Assert.assertEquals(3.3, ((TeleportEvent) cutscene.events.get(1)).z, 0);
+		Assert.assertEquals(4.4, ((TeleportEvent) cutscene.events.get(1)).pitch, 0.01);
+		Assert.assertEquals(5.5, ((TeleportEvent) cutscene.events.get(1)).yaw, 0.01);
 
-        Assert.assertEquals(6.6, ((SmoothMoveEvent) cutscene.events.get(2)).x, 0);
-        Assert.assertEquals(7.7, ((SmoothMoveEvent) cutscene.events.get(2)).y, 0);
-        Assert.assertEquals(8.8, ((SmoothMoveEvent) cutscene.events.get(2)).z, 0);
-        Assert.assertEquals(9.9, ((SmoothMoveEvent) cutscene.events.get(2)).pitch, 0.01);
-        Assert.assertEquals(10 , ((SmoothMoveEvent) cutscene.events.get(2)).yaw, 0.01);
+		Assert.assertEquals(6.6, ((SmoothMoveEvent) cutscene.events.get(2)).x, 0);
+		Assert.assertEquals(7.7, ((SmoothMoveEvent) cutscene.events.get(2)).y, 0);
+		Assert.assertEquals(8.8, ((SmoothMoveEvent) cutscene.events.get(2)).z, 0);
+		Assert.assertEquals(9.9, ((SmoothMoveEvent) cutscene.events.get(2)).pitch, 0.01);
+		Assert.assertEquals(10 , ((SmoothMoveEvent) cutscene.events.get(2)).yaw, 0.01);
 
-        Assert.assertEquals("Test Title", ((CaptionEvent) cutscene.events.get(3)).title);
-        Assert.assertEquals("Test Subtitle", ((CaptionEvent) cutscene.events.get(3)).subtitle);
+		Assert.assertEquals("Test Title", ((CaptionEvent) cutscene.events.get(3)).title);
+		Assert.assertEquals("Test Subtitle", ((CaptionEvent) cutscene.events.get(3)).subtitle);
 
-        Blockly2Java.registerClass(Dialogue.class);
-        Blockly2Java.registerClass(DialogueClose.class);
-        Blockly2Java.registerClass(DialogueOpenDialogue.class);
-        Blockly2Java.registerClass(DialogueOption.class);
-        Blockly2Java.registerClass(DialogueSayMessage.class);
+		Blockly2Java.registerClass(Dialogue.class);
+		Blockly2Java.registerClass(DialogueClose.class);
+		Blockly2Java.registerClass(DialogueOpenDialogue.class);
+		Blockly2Java.registerClass(DialogueOption.class);
+		Blockly2Java.registerClass(DialogueSayMessage.class);
 
-        ArrayList<Object> dialogues = Blockly2Java.parseBlockly(dialogueInput);
-        Assert.assertEquals("base", ((Dialogue) dialogues.get(0)).name);
-        Assert.assertEquals("testy", ((Dialogue) dialogues.get(1)).name);
-        Assert.assertEquals("whoami", ((Dialogue) dialogues.get(2)).name);
-    }
+		ArrayList<Object> dialogues = Blockly2Java.parseBlockly(dialogueInput);
+		Assert.assertEquals("base", ((Dialogue) dialogues.get(0)).name);
+		Assert.assertEquals("testy", ((Dialogue) dialogues.get(1)).name);
+		Assert.assertEquals("whoami", ((Dialogue) dialogues.get(2)).name);
+	}
+
+	@Test
+	public void testMultiValueBlock() throws Exception {
+		Blockly2Java.registerClass(Cutscene.class);
+		Blockly2Java.registerClass(Data.class);
+		Blockly2Java.registerClass(DelayEvent.class);
+		Blockly2Java.registerClass(ComplexDelayEvent.class);
+		Blockly2Java.registerClass(ComplexTime.class);
+
+		Cutscene cutscene = (Cutscene) Blockly2Java.parseBlockly(complexCutsceneInput).get(0);
+
+		Assert.assertNotNull(((ComplexDelayEvent) cutscene.events.get(1)).end);
+
+	}
 
 }

--- a/src/test/java/me/vilsol/blockly2java/objects/ComplexDelayEvent.java
+++ b/src/test/java/me/vilsol/blockly2java/objects/ComplexDelayEvent.java
@@ -1,0 +1,15 @@
+package me.vilsol.blockly2java.objects;
+
+import me.vilsol.blockly2java.annotations.BBlock;
+import me.vilsol.blockly2java.annotations.BValue;
+
+@BBlock("event_complex_delay")
+public class ComplexDelayEvent extends Event {
+
+	@BValue("START")
+	public ComplexTime start;
+
+	@BValue("END")
+	public ComplexTime end;
+
+}

--- a/src/test/java/me/vilsol/blockly2java/objects/ComplexTime.java
+++ b/src/test/java/me/vilsol/blockly2java/objects/ComplexTime.java
@@ -1,0 +1,15 @@
+package me.vilsol.blockly2java.objects;
+
+import me.vilsol.blockly2java.annotations.BBlock;
+import me.vilsol.blockly2java.annotations.BField;
+
+@BBlock("complex_time")
+public class ComplexTime {
+
+	@BField("MINUTES")
+	public int minutes;
+
+	@BField("SECONDS")
+	public int seconds;
+
+}


### PR DESCRIPTION
While parsing statements with multiple child blocks, it seems that in some situations simply incrementing/decrementing the _ignoreBlocks_ counter is not sufficient. Specifically, I encountered the issue in the case of statement containing two child blocks, each of which contains two values and the values being blocks themselves. In this case one of the values in the second child is parsed incorrectly (resulting in null value). 
This is demonstrated in the provided test case _testMultiValueBlock_. The proposed solution involves keeping track of the specific block id's which should be ignored, instead of just incrementing the counter when node named 'next' is encountered and decrementing it on the next encountered closing block tag.